### PR TITLE
Add FFMPEG/x264 support

### DIFF
--- a/AppWebStream.vcxproj
+++ b/AppWebStream.vcxproj
@@ -87,11 +87,13 @@
       </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(FFMPEG_ROOT)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(FFMPEG_ROOT)\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -101,10 +103,12 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(FFMPEG_ROOT)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(FFMPEG_ROOT)\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -115,13 +119,15 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(FFMPEG_ROOT)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(FFMPEG_ROOT)\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -133,12 +139,14 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalIncludeDirectories>$(FFMPEG_ROOT)\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(FFMPEG_ROOT)\lib</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/COPY_FFMPEG_DLLs.bat
+++ b/COPY_FFMPEG_DLLs.bat
@@ -1,0 +1,9 @@
+@echo off
+
+mkdir x64\Debug
+copy /y %FFMPEG_ROOT%\bin\*.dll x64\Debug
+
+mkdir x64\Relase
+copy /y %FFMPEG_ROOT%\bin\*.dll x64\Relase
+
+::pause

--- a/Main.cpp
+++ b/Main.cpp
@@ -131,7 +131,11 @@ int main (int argc, char *argv[]) {
     auto ws = CreateLocalInstance<WebStream>();
     ws->SetPortAndWindowHandle(port, win_handle);
     const unsigned int FPS = 25;
+#ifdef ENABLE_FFMPEG
+    VideoEncoderFF encoder(dims, FPS, ws);
+#else
     VideoEncoderMF encoder(dims, FPS, ws);
+#endif
 
     // encode & transmit frames
     HRESULT hr = S_OK;

--- a/Main.cpp
+++ b/Main.cpp
@@ -131,7 +131,7 @@ int main (int argc, char *argv[]) {
     auto ws = CreateLocalInstance<WebStream>();
     ws->SetPortAndWindowHandle(port, win_handle);
     const unsigned int FPS = 25;
-    VideoEncoder encoder(dims, FPS, ws);
+    VideoEncoderMF encoder(dims, FPS, ws);
 
     // encode & transmit frames
     HRESULT hr = S_OK;

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # AppWebStream
-[Windows Media Foundation](https://msdn.microsoft.com/en-us/library/ms694197.aspx)-based sample code for streaming an application window to a web browser. The video is encoded as a H.264 stream inside a fragmented MPEG4 container. The byte-stream is modified as described in https://stackoverflow.com/questions/49429954/mfcreatefmpeg4mediasink-does-not-generate-mse-compatible-mp4 to make it Media Source Extensions (MSE) compatible, so that it can be received by any modern web browser with minimal client-side buffering.
+[Windows Media Foundation](https://msdn.microsoft.com/en-us/library/ms694197.aspx) and [FFMPEG](http://ffmpeg.org/) sample code for streaming an application window to a web browser. The video is encoded as a H.264 stream inside a fragmented MPEG4 container. The byte-stream is modified as described in https://stackoverflow.com/questions/49429954/mfcreatefmpeg4mediasink-does-not-generate-mse-compatible-mp4 to make it Media Source Extensions (MSE) compatible, so that it can be received by any modern web browser with minimal client-side buffering.
 
 The streaming is primarily tested on and works best with Google Chrome. It also works with Microsoft Edge, although with a higher latency. Mozilla Firefox is not yet supported.
 
@@ -10,5 +10,7 @@ The streaming is primarily tested on and works best with Google Chrome. It also 
 * Start `WebAppStream.exe [window handle] [port]`. You can use Spy++ (included with Visual Studio) to determine window handles.
 * Open `localhost:[port]` in web browser, or on another computer.
 
-### Outstanding issues
+To build with FFMPG, you first need to download & unzip FFMPEG binaries to a folder pointed to by the `FFMPEG_ROOT` environment variable. Then, set the `ENABLE_FFMPEG` preprocessor define before building.
+
+### Media Foundation issues
 * The MPEG4 fragments are transmitted 8 frames at a time over the network. Can be verified by inspecting the `sample_count` variable in `MP4FragmentEditor::ProcessTrackFrameChildren`. This leads to a 8 frame latency both at the server- and client-side. For a 25fps stream, this yields a minimum latency of 2 * 8frames * 40ms/frame = 640ms.

--- a/VideoEncoder.hpp
+++ b/VideoEncoder.hpp
@@ -4,6 +4,8 @@
 #include <vector>
 #include <array>
 #include <cassert>
+#include <Windows.h>
+#include <mfapi.h>
 
 /** 32bit color value. */
 struct R8G8B8A8 {
@@ -14,8 +16,6 @@ struct R8G8B8A8 {
 };
 
 #ifndef ENABLE_FFMPEG
-#include <Windows.h>
-#include <mfapi.h>
 #include <mfidl.h>
 #include <Mfreadwrite.h>
 #include <Ks.h>
@@ -37,6 +37,22 @@ _COM_SMARTPTR_TYPEDEF(IMFMediaBuffer, __uuidof(IMFMediaBuffer));
 _COM_SMARTPTR_TYPEDEF(IMFSample,      __uuidof(IMFSample));
 _COM_SMARTPTR_TYPEDEF(IMFMediaType,   __uuidof(IMFMediaType));
 #else
+
+#pragma comment(lib, "avcodec.lib")
+#pragma comment(lib, "avformat.lib")
+#pragma comment(lib, "avutil.lib")
+
+#include <cassert>
+#include <stdexcept>
+#include <fstream>
+#include <tuple>
+#include <vector>
+
+extern "C" {
+#include <libavutil/opt.h>
+#include <libavformat/avformat.h>
+}
+
 #endif
 
 
@@ -70,8 +86,11 @@ public:
         return {m_width, m_height};
     }
 
+    virtual HRESULT   WriteFrame (R8G8B8A8* src_data, bool swap_rb) {
+        throw std::logic_error("not implemented");
+    }
+
     virtual R8G8B8A8* WriteFrameBegin () = 0;
-    virtual HRESULT   WriteFrame (R8G8B8A8* src_data, bool swap_rb) = 0;
     virtual HRESULT   WriteFrameEnd () = 0;
 
 protected:
@@ -263,5 +282,247 @@ private:
 };
 
 #else
+
+
+class VideoEncoderFF : public VideoEncoder {
+public:
+    /** Stream writing callback. */
+    static int WritePackage (void *opaque, uint8_t *buf, int buf_size) {
+        IMFByteStream * stream = reinterpret_cast<IMFByteStream*>(opaque);
+        ULONG bytes_written = 0;
+        if (FAILED(stream->Write(buf, buf_size, &bytes_written)))
+            return -1;
+
+        return buf_size;
+    }
+
+    VideoEncoderFF (std::array<unsigned short, 2> dimensions, unsigned int fps, IMFByteStream * socket) : VideoEncoder(dimensions), m_fps(fps) {
+        av_register_all();
+
+        /* allocate the output media context */
+        avformat_alloc_output_context2(&out_ctx, nullptr, "mp4", nullptr);
+        if (!out_ctx)
+            throw std::runtime_error("avformat_alloc_output_context2 failure");
+
+        // Add the video streams using the default format codecs and initialize the codecs
+        AVCodec * video_codec = nullptr;
+        std::tie(video_codec, stream, enc) = add_stream(out_ctx->oformat->video_codec, out_ctx);
+
+        AVDictionary *opt = nullptr;
+        av_dict_set(&opt, "movflags", "empty_moov+default_base_moof+frag_keyframe", 0); // fragmented MP4
+
+                                                                                        // open the video codecs and allocate the necessary encode buffers
+        frame = open_video(video_codec, opt, enc, stream->codecpar);
+
+#ifndef NDEBUG
+        // write info to console
+        av_dump_format(out_ctx, 0, nullptr, 1);
+#endif
+
+        m_rgb_buf.resize(Align(m_width)*Align(m_height));
+
+        m_out_buf.resize(16*1024*1024); // 16MB
+        out_ctx->pb = avio_alloc_context(m_out_buf.data(), static_cast<int>(m_out_buf.size()), 1/*writable*/, socket, nullptr/*read*/, WritePackage, nullptr/*seek*/);
+        //out_ctx->flags |= AVFMT_FLAG_CUSTOM_IO;
+
+        // Write the stream header, if any
+        int ret = avformat_write_header(out_ctx, &opt);
+        if (ret < 0)
+            throw std::runtime_error("avformat_write_header failed");
+    }
+
+    ~VideoEncoderFF() {
+        // flush encoder to mark end of stream
+        WriteFrameImpl(false);
+
+        // write file ending (discard error codes)
+        av_write_trailer(out_ctx);
+
+        avcodec_close(enc);
+        avcodec_free_context(&enc);
+
+        av_frame_free(&frame);
+
+        avio_context_free(&out_ctx->pb);
+        avformat_free_context(out_ctx);
+    }
+
+    R8G8B8A8* WriteFrameBegin () override {
+        return m_rgb_buf.data();
+    }
+
+    HRESULT   WriteFrameEnd () override {
+        return WriteFrameImpl(true);
+    }
+
+    HRESULT WriteFrameImpl (bool has_frame) {
+        if (has_frame) {
+            if (av_frame_make_writable(frame) < 0)
+                exit(1);
+
+            assert(enc->pix_fmt == AV_PIX_FMT_YUV420P);
+
+            // RGB to YUV conversion
+            for (int y = 0; y < m_height; y++) {
+                for (int x = 0; x < m_width; x++) {
+                    // flip upside down
+                    R8G8B8A8 rgb = m_rgb_buf[(m_height-1-y)*enc->width + x];
+                    // convert to YUV
+                    unsigned char Y=0, U=0, V=0;
+                    YUVfromRGB(rgb, Y, U, V);
+                    // write Y value
+                    frame->data[0][y*frame->linesize[0] + x] = Y;
+                    // write subsambled Cb,Cr values
+                    if (((x % 2) == 0) && ((y % 2) == 0)) {
+                        frame->data[1][y/2*frame->linesize[1] + x/2] = V/4;
+                        frame->data[2][y/2*frame->linesize[2] + x/2] = U/4;
+                    } else {
+                        frame->data[1][y/2*frame->linesize[1] + x/2] += V/4;
+                        frame->data[2][y/2*frame->linesize[2] + x/2] += U/4;
+                    }
+                }
+            }
+
+            frame->pts = next_pts;
+            next_pts++; // increment next pts
+        }
+
+        // encode frame
+        int ret = avcodec_send_frame(enc, has_frame ? frame : nullptr);
+        if (ret < 0)
+            throw std::runtime_error("Error encoding video frame");
+
+        AVPacket pkt = {};
+        av_init_packet(&pkt);
+
+        // process packages
+        for (;;) {
+            ret = avcodec_receive_packet(enc, &pkt);
+            if (ret == AVERROR(EAGAIN))
+                break; // not yet available
+            else if (!has_frame && (ret == AVERROR_EOF))
+                break; // end of stream
+            else if (ret < 0)
+                throw std::runtime_error("avcodec_receive_packet failed");
+
+            // rescale output packet timestamp values from codec to stream timebase
+            av_packet_rescale_ts(&pkt, enc->time_base, stream->time_base);
+            pkt.stream_index = stream->index;
+
+            // write compressed frame to stream
+            ret = av_interleaved_write_frame(out_ctx, &pkt);
+            if (ret < 0)
+                return E_FAIL;
+        }
+
+        return S_OK;
+    }
+
+private:
+    /* Add an output stream. */
+    std::tuple<AVCodec*,AVStream*, AVCodecContext*> add_stream (AVCodecID codec_id, /*in/out*/AVFormatContext *out_ctx) {
+        // find the encoder
+        AVCodec *codec = avcodec_find_encoder(codec_id);
+        if (!codec) {
+            const char * name = avcodec_get_name(codec_id);
+            throw std::runtime_error("Could not find encoder for");
+        }
+        assert(codec->type == AVMEDIA_TYPE_VIDEO);
+
+        AVStream * stream = avformat_new_stream(out_ctx, NULL);
+        if (!stream)
+            throw std::runtime_error("Could not allocate stream");
+
+        stream->id = out_ctx->nb_streams-1;
+
+        // setup context
+        AVCodecContext *enc = avcodec_alloc_context3(codec);
+        if (!enc)
+            throw std::runtime_error("Could not alloc an encoding context");
+        {
+            enc->codec_id = codec_id;
+            enc->bit_rate = 4*1024*1024; // 4Mb/s
+            // Resolution must be a multiple of two
+            enc->width    = Align(m_width);
+            enc->height   = Align(m_height);
+            /* timebase: This is the fundamental unit of time (in seconds) in terms
+            * of which frame timestamps are represented. For fixed-fps content,
+            * timebase should be 1/framerate and timestamp increments should be
+            * identical to 1. */
+            enc->time_base = { 1, static_cast<int>(m_fps) };
+
+            enc->gop_size = 0; // only intra-frames (reduces latency)
+            enc->pix_fmt  = AV_PIX_FMT_YUV420P; // default pix_fmt
+
+            int res = av_opt_set(enc->priv_data, "tune", "zerolatency", 0);
+            if (res < 0)
+                throw std::runtime_error("zerolatency tuning failed");
+
+            // Some formats want stream headers to be separate
+            if (out_ctx->oformat->flags & AVFMT_GLOBALHEADER)
+                enc->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;
+        }
+
+        stream->time_base = enc->time_base;
+        return std::tie(codec, stream, enc);
+    }
+
+    static AVFrame *alloc_frame (enum AVPixelFormat pix_fmt, int width, int height) {
+        AVFrame* picture = av_frame_alloc();
+        assert(picture);
+
+        picture->format = pix_fmt;
+        picture->width  = width;
+        picture->height = height;
+
+        // allocate the buffers for the frame data
+        int ret = av_frame_get_buffer(picture, 32);
+        if (ret < 0)
+            throw std::runtime_error("Could not allocate frame data");
+
+        return picture;
+    }
+
+    static AVFrame* open_video (const AVCodec *codec, const AVDictionary *opt_arg, /*in/out*/AVCodecContext *c, /*in/out*/AVCodecParameters *codecpar) {
+        AVDictionary *opt = nullptr;
+        av_dict_copy(&opt, opt_arg, 0);
+
+        /* open the codec */
+        int ret = avcodec_open2(c, codec, &opt);
+        av_dict_free(&opt);
+        if (ret < 0)
+            throw std::runtime_error("Could not open video codec");
+
+        /* allocate and init a re-usable frame */
+        AVFrame* frame = alloc_frame(c->pix_fmt, c->width, c->height);
+        if (!frame)
+            throw std::runtime_error("Could not allocate video frame");
+
+        assert(c->pix_fmt == AV_PIX_FMT_YUV420P);
+
+        // copy the stream parameters to the muxer
+        ret = avcodec_parameters_from_context(codecpar, c);
+        if (ret < 0)
+            throw std::runtime_error("Could not copy the stream parameters");
+
+        return frame;
+    }
+
+    static void YUVfromRGB (const R8G8B8A8 rgb, unsigned char& Y, unsigned char& U, unsigned char& V) {
+        Y = static_cast<unsigned char>( 0.257f*rgb.r + 0.504f*rgb.g + 0.098f*rgb.b +  16);
+        U = static_cast<unsigned char>(-0.148f*rgb.r - 0.291f*rgb.g + 0.439f*rgb.b + 128);
+        V = static_cast<unsigned char>( 0.439f*rgb.r - 0.368f*rgb.g - 0.071f*rgb.b + 128);
+    }
+
+    unsigned int       m_fps = 0;
+    int64_t         next_pts = 0; // pts of the next frame that will be generated
+    AVFormatContext *out_ctx = nullptr;
+    AVStream         *stream = nullptr;
+    AVCodecContext      *enc = nullptr;
+    AVFrame           *frame = nullptr;
+
+    std::vector<R8G8B8A8>      m_rgb_buf;
+    std::vector<unsigned char> m_out_buf;
+};
 
 #endif

--- a/VideoEncoder.hpp
+++ b/VideoEncoder.hpp
@@ -5,6 +5,15 @@
 #include <array>
 #include <cassert>
 
+/** 32bit color value. */
+struct R8G8B8A8 {
+    unsigned char r;
+    unsigned char g;
+    unsigned char b;
+    unsigned char a;
+};
+
+#ifndef ENABLE_FFMPEG
 #include <Windows.h>
 #include <mfapi.h>
 #include <mfidl.h>
@@ -23,18 +32,12 @@
 #pragma comment(lib, "Strmiids.lib")
 
 
-/** 32bit color value. */
-struct R8G8B8A8 {
-    unsigned char r;
-    unsigned char g;
-    unsigned char b;
-    unsigned char a;
-};
-
 _COM_SMARTPTR_TYPEDEF(IMFSinkWriter,  __uuidof(IMFSinkWriter));
 _COM_SMARTPTR_TYPEDEF(IMFMediaBuffer, __uuidof(IMFMediaBuffer));
 _COM_SMARTPTR_TYPEDEF(IMFSample,      __uuidof(IMFSample));
 _COM_SMARTPTR_TYPEDEF(IMFMediaType,   __uuidof(IMFMediaType));
+#else
+#endif
 
 
 /** Converts unicode string to ASCII */
@@ -76,7 +79,7 @@ protected:
     const unsigned short m_height;
 };
 
-
+#ifndef ENABLE_FFMPEG
 /** Media-Foundation-based H.264 video encoder. */
 class VideoEncoderMF : public VideoEncoder {
 public:
@@ -258,3 +261,7 @@ private:
     IMFMediaBufferPtr        m_buffer;
     unsigned long            m_stream_index = 0;
 };
+
+#else
+
+#endif

--- a/WebStream.cpp
+++ b/WebStream.cpp
@@ -123,7 +123,9 @@ HRESULT STDMETHODCALLTYPE WebStream::EndRead(/*in*/IMFAsyncResult* /*result*/, /
 }
 
 HRESULT WebStream::WriteImpl(/*in*/const BYTE* pb, /*in*/ULONG cb) {
+#ifndef ENABLE_FFMPEG
     std::tie(pb,cb) = m_impl->m_stream_editor.ModifyMovieFragment(pb, cb);
+#endif
 
     int byte_count = send(m_impl->m_stream_client->Socket(), reinterpret_cast<const char*>(pb), cb, 0);
     if (byte_count == SOCKET_ERROR) {
@@ -161,8 +163,10 @@ HRESULT STDMETHODCALLTYPE WebStream::BeginWrite(/*in*/const BYTE* pb, /*in*/ULON
      m_tmp_bytes_written = cb;
 
     CComPtr<IMFAsyncResult> async_res;
+#ifndef ENABLE_FFMPEG
     if (FAILED(MFCreateAsyncResult(nullptr, callback, unkState, &async_res)))
         throw std::runtime_error("MFCreateAsyncResult failed");
+#endif
     
     hr = callback->Invoke(async_res); // will trigger EndWrite
     return hr;


### PR DESCRIPTION
To build with FFMPG, you first need to download & unzip FFMPEG binaries to a folder pointed to by the `FFMPEG_ROOT` environment variable. Then, set the `ENABLE_FFMPEG` preprocessor define before building.