### PR TITLE
Stop calling av_register_all() in FFMPEG 4.0 & newer

### DIFF
--- a/VideoEncoder.hpp
+++ b/VideoEncoder.hpp
@@ -297,7 +297,9 @@ public:
     }
 
     VideoEncoderFF (std::array<unsigned short, 2> dimensions, unsigned int fps, IMFByteStream * socket) : VideoEncoder(dimensions), m_fps(fps) {
+#if LIBAVFORMAT_VERSION_MAJOR < 58
         av_register_all();
+#endif
 
         /* allocate the output media context */
         avformat_alloc_output_context2(&out_ctx, nullptr, "mp4", nullptr);


### PR DESCRIPTION
Function have been deprecated and no longer necessary to call.