### PR TITLE
Use NotifyEndOfSegment to simplify & reduce encoding latency

### DIFF
--- a/Main.cpp
+++ b/Main.cpp
@@ -148,8 +148,8 @@ int main (int argc, char *argv[]) {
     ws->SetPortAndWindowHandle(port, win_handle, 1); // blocking call
     VideoEncoderFF encoder(dims, FPS, ws);
 #else
-    ws->SetPortAndWindowHandle(port, win_handle, FPS); // blocking call
-    VideoEncoderMF encoder(dims, 1, ws);
+    ws->SetPortAndWindowHandle(port, win_handle, 1); // blocking call
+    VideoEncoderMF encoder(dims, FPS, ws);
 #endif
     std::cout << "Connecting to client..." << std::endl;
 

--- a/Main.cpp
+++ b/Main.cpp
@@ -145,10 +145,10 @@ int main (int argc, char *argv[]) {
     std::cout << "Starting web server to stream window " << std::hex << win_handle << ". Please connect with a web browser on port " <<port << " to receive the stream" << std::endl;
     auto ws = CreateLocalInstance<WebStream>();
 #ifdef ENABLE_FFMPEG
-    ws->SetPortAndWindowHandle(port, win_handle, 1); // blocking call
+    ws->SetPortAndWindowHandle(port, win_handle); // blocking call
     VideoEncoderFF encoder(dims, FPS, ws);
 #else
-    ws->SetPortAndWindowHandle(port, win_handle, 1); // blocking call
+    ws->SetPortAndWindowHandle(port, win_handle); // blocking call
     VideoEncoderMF encoder(dims, FPS, ws);
 #endif
     std::cout << "Connecting to client..." << std::endl;

--- a/VideoEncoder.hpp
+++ b/VideoEncoder.hpp
@@ -254,6 +254,9 @@ public:
         if (FAILED(hr))
             return hr;
 
+        // transmit frame immediately
+        COM_CHECK(m_sink_writer->NotifyEndOfSegment(m_stream_index));
+
         // increment time
         m_time_stamp += m_frame_duration;
         return S_OK;

--- a/WebStream.cpp
+++ b/WebStream.cpp
@@ -7,7 +7,7 @@
 
 
 struct WebStream::impl : public StreamSockSetter {
-    impl(const char * port_str, HWND wnd, unsigned int time_scale_multiplier) : m_server(port_str), m_block_ctor(true), m_wnd(wnd), m_stream_editor(time_scale_multiplier) {
+    impl(const char * port_str, HWND wnd) : m_server(port_str), m_block_ctor(true), m_wnd(wnd) {
         // start server thread
         m_thread = std::thread(&WebStream::impl::WaitForClients, this);
 
@@ -80,8 +80,8 @@ WebStream::WebStream() {
 WebStream::~WebStream() {
 }
 
-void WebStream::SetPortAndWindowHandle(const char * port_str, HWND wnd, unsigned int time_scale_multiplier) {
-    m_impl = std::make_unique<impl>(port_str, wnd, time_scale_multiplier);
+void WebStream::SetPortAndWindowHandle(const char * port_str, HWND wnd) {
+    m_impl = std::make_unique<impl>(port_str, wnd);
 }
 
 HRESULT STDMETHODCALLTYPE WebStream::GetCapabilities(/*out*/DWORD *capabilities) {

--- a/WebStream.hpp
+++ b/WebStream.hpp
@@ -16,7 +16,7 @@ public:
     WebStream();
     /*NOT virtual*/ ~WebStream();
 
-    void SetPortAndWindowHandle(const char * port_str, HWND wnd, unsigned int time_scale_multiplier);
+    void SetPortAndWindowHandle(const char * port_str, HWND wnd);
 
     HRESULT STDMETHODCALLTYPE GetCapabilities(/*out*/DWORD *capabilities) override;
 


### PR DESCRIPTION
Based on #15 where @oreh-a suggested to use [NotifyEndOfSegment ](https://docs.microsoft.com/en-us/windows/win32/api/mfreadwrite/nf-mfreadwrite-imfsinkwriter-notifyendofsegment) to reduce the encoding latency.

I'm experiencing that this reduces the encoding latency from 1-2 frames down to 0-1 frames.

### Test results
Test setup:
* Disable `MF_READWRITE_ENABLE_HARDWARE_TRANSFORMS` to get GPU driver differences out of the equation.
* Place breakpoints in the `EncodeFrame` function as well as `WebStream::WriteImpl` (with condition `cb > 1024`).

**Baseline call sequence**:
1. EncodeFrame
2. EncodeFrame
3. EncodeFrame
4. WriteImpl (latency 2)
5. EncodeFrame
6. WriteImpl (latency 2)
7. WriteImpl (latency 1)
8. EncodeFrame
9. WriteImpl (latency 1)
10. EncodeFrame
11. ...

**Call sequence with this PR**:
1. EncodeFrame
2. EncodeFrame
3. WriteImpl (latency 1)
4. EncodeFrame
5. WriteImpl (latency 1)
6. EncodeFrame
7. WriteImpl (latency 1)
8. WriteImpl (latency 0)
9. EncodeFrame
10. WriteImpl (latency 0)
11. ...

